### PR TITLE
Added cast of void pointer

### DIFF
--- a/gpio-dma-test.c
+++ b/gpio-dma-test.c
@@ -312,7 +312,7 @@ void run_cpu_from_memory_set_reset() {
  */
 void run_cpu_from_uncached_memory_set_reset() {
   // Prepare GPIO
-  volatile uint32_t *gpio_port = mmap_bcm_register(GPIO_REGISTER_BASE);
+  volatile uint32_t *gpio_port = (uint32_t *) mmap_bcm_register(GPIO_REGISTER_BASE);
   initialize_gpio_for_output(gpio_port, TOGGLE_GPIO);
   volatile uint32_t *set_reg = gpio_port + (GPIO_SET_OFFSET / sizeof(uint32_t));
   volatile uint32_t *clr_reg = gpio_port + (GPIO_CLR_OFFSET / sizeof(uint32_t));


### PR DESCRIPTION
Added cast of void pointer to uint32_t.  Without this, I received the following compiler error:

main.cpp: In function ‘void run_cpu_direct()’:
main.cpp:994:50: error: invalid conversion from ‘void*’ to ‘volatile uint32_t*’ {aka ‘volatile unsigned int*’} [-fpermissive]
  volatile uint32_t* gpio_port = mmap_bcm_register(GPIO_REGISTER_BASE);